### PR TITLE
center and warp projects icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <link rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/">
 <link rel="stylesheet" href="https://meta.wikimedia.org/w/load.php?debug=false&amp;lang=en&amp;modules=ext.gadget.wm-portal&amp;only=styles&amp;skin=vector&amp;*">
 <style type="text/css">
-  .nowrap{white-space:nowrap}#intro{text-align:justify;vertical-align:top;width:70%;font-size:150%;margin:0 auto;padding:.5em 1em}.otherprojects{width:75%}.otherprojects-item{height:175px;min-width:150px;max-width:300px;line-height:175px}.otherprojects-item a,.otherprojects-item .icon{width:150px}#footer{clear:both;text-align:center;width:70%;margin:10px auto;border-top:.5px solid #aaa}#footer ul,#footer ul li{display:inline;padding:0;margin:0 10px}
+  .nowrap{white-space:nowrap}#intro{text-align:justify;vertical-align:top;width:70%;font-size:150%;margin:0 auto;padding:.5em 1em}.otherprojects{width:100%;display: flex;justify-content: center;flex-wrap: wrap;}.otherprojects-item{height:175px;min-width:150px;max-width:300px;line-height:175px}.otherprojects-item a,.otherprojects-item .icon{width:150px}#footer{clear:both;text-align:center;width:70%;margin:10px auto;border-top:.5px solid #aaa}#footer ul,#footer ul li{display:inline;padding:0;margin:0 10px}
 </style>
 </head>
 <body>


### PR DESCRIPTION
fixes: #2 

<table>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/2ce07895-cbbf-4cd0-a354-3c0cf833b771" />
</td>
<td>
<img src="https://github.com/user-attachments/assets/20d96724-5a7d-40df-90e9-61f4c3d4a536" />
</td>
</tr>
</table>

## action
This PR fixes the issue where the project icons were not centered and not aligned in a single line. it just needs to wraps them using flex. That's what this PR does. Thanks!